### PR TITLE
yargs options using builder property

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ This repository is based on the Udemy course  [The Complete Node.js Developer Co
    * Require and use chalk npm module
    * Get the arguments entered in console. e.g. `node app.js add`  `process.argv` - argument vector (array) - first node path executable on your machine, path to app.js, value you provided
    * Setting up yargs commands for add, remove, read and list.
+   * Adding and defining yargs options, using the `builder` property.
+   * Replacing `console.log(yargs.argv)` with `yargs.parse` to skip the duplicate printing, but still allow to parse the options.
 * `notes.txt` File created as a result of the above mentioned file. Appended by running script from ch-1-append-file.js
 * `notes.js` Functions to be called in app.js file
 

--- a/notes-app/app.js
+++ b/notes-app/app.js
@@ -31,8 +31,21 @@ const getNotes = require('./notes.js');
 yargs.command({
     command: 'add',
     describe: 'Add a new note',
-    handler: function () {
-        console.log('Adding a new note')
+    builder: {
+        title: {
+            describe: 'Add a new note',
+            demandOption: true,
+            type: 'string'
+        },
+        body: {
+            describe: 'Description of the note',
+            demandOption: true,
+            type: 'string'
+        }
+    },
+    handler: function (argv) {
+        console.log(chalk.gray('Title: '), chalk.bold.green(argv.title)),
+            console.log(chalk.gray('Body:  '), chalk.green(argv.body))
     }
 })
 
@@ -47,8 +60,15 @@ yargs.command({
 yargs.command({
     command: 'read',
     describe: 'Read existing note',
-    handler: function () {
-        console.log('Reading this specific note')
+    builder: {
+        title: {
+            describe: 'Note title',
+            demandOption: true,
+            type: 'string'
+        }
+    },
+    handler: function (argv) {
+        console.log('Reading note: ', chalk.bold(argv.title))
     }
 })
 
@@ -60,4 +80,5 @@ yargs.command({
     }
 })
 
-console.log(yargs.argv);
+yargs.parse()
+// console.log(yargs.argv);


### PR DESCRIPTION
* Adding and defining yargs options, using the `builder` property.
* Replacing `console.log(yargs.argv)` with `yargs.parse` to skip the duplicate printing, but still allow to parse the options.
![image](https://user-images.githubusercontent.com/79845207/136169275-ccb96432-5243-4a1c-adb2-c64b90e8b6c7.png)
