### PR TITLE
refactoring forecast using callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,16 @@ This repository is based on the Udemy course  [The Complete Node.js Developer Co
    * calling WeatherStack API key, using the `request({url:url}, (error, response) => {}) function
       * one of `error` or `response` is always going to be undefined.
    * printing a small forecast to the user (using `WeatherStack` API)
-   * calling geocode function from `utils/geocode.js`
+   * calling & returning geocode using a callback function `utils/geocode.js`
+   * calling & returning forecast using a callback function `utils/geocode.js`
 * `utils/geocode.js` 
    * geocode callback function using `mapbox` api
+   * Error handling 
+      * low level errors, where error argument exists and response is not defined
+      * no matching results - there is a response but with error code
+   * returning respective data in callback
+* `utils/forecast.js` 
+   * forecast callback function using `weatherStack` api
    * Error handling 
       * low level errors, where error argument exists and response is not defined
       * no matching results - there is a response but with error code

--- a/weather-app/app.js
+++ b/weather-app/app.js
@@ -3,33 +3,18 @@ const config = require('../config.js');
 const chalk = require('chalk');
 const { features } = require('process');
 const geocode = require('./utils/geocode.js')
-
-// Weather API
-const weatherAPI = config.keys.WEATHERSTACK_KEY;
-const weatherUrl = `http://api.weatherstack.com/current?access_key=${weatherAPI}&query=37.8267,-122.4233`;
-// printing a small forecast to the user 
-request({ url: weatherUrl, json: true }, (error, response) => {
-    if (error) {
-        console.log(chalk.red('Unable to connect to weather service'))
-    } else if (response.body.error) {
-        console.log('The following error have been found:')
-        console.log(chalk.red.bold(response.body.error.info))
-    } else {
-        data = response.body.current;
-        console.log('It is currently ' + chalk.green.bold(data.temperature) + ' degrees out! It feels like ' + chalk.yellow.bold(data.feelslike) + ' degrees out. It is ' + chalk.green(data.weather_descriptions[0].toLowerCase()) + '.'
-        )
-    }
-});
+const forecast = require('./utils/forecast.js')
 
 
-geocode('Boston', (error, data) => {
-    if (error) {
-        console.log(chalk.red.bold(error))
-    } else {
-        console.log(data)
-    }
+geocode('Berlin', (error, data) => {
+    console.log('Error', error)
+    console.log('Data', data)
 })
 
+forecast(13.38333, 52.51667, (error, data) => {
+    console.log('Error', error)
+    console.log('Data', data)
+})
 
 // console.log('Starting..');
 // setTimeout(() => {
@@ -39,6 +24,9 @@ geocode('Boston', (error, data) => {
 //     console.log('0 second timer')
 // }, 0);
 // console.log('Stopping..');
+
+
+
 
 // printing longitude and latitude for Los Angeles
 // request({ url: mapboxUrl, json: true }, (error, response) => {
@@ -56,3 +44,18 @@ geocode('Boston', (error, data) => {
 //         console.log('Latitude: ' + chalk.bold.yellow(data[0].center[1]));
 //     }
 // })
+
+
+// printing a small forecast to the user 
+// request({ url: weatherUrl, json: true }, (error, response) => {
+//     if (error) {
+//         console.log(chalk.red('Unable to connect to weather service'))
+//     } else if (response.body.error) {
+//         console.log('The following error have been found:')
+//         console.log(chalk.red.bold(response.body.error.info))
+//     } else {
+//         data = response.body.current;
+//         console.log('It is currently ' + chalk.green.bold(data.temperature) + ' degrees out! It feels like ' + chalk.yellow.bold(data.feelslike) + ' degrees out. It is ' + chalk.green(data.weather_descriptions[0].toLowerCase()) + '.'
+//         )
+//     }
+// });

--- a/weather-app/utils/forecast.js
+++ b/weather-app/utils/forecast.js
@@ -1,0 +1,25 @@
+const config = require('../../config.js');
+const request = require('postman-request');
+const chalk = require('chalk');
+
+
+const forecast = (longitude, latitude, callback) => {
+    // Weather API
+    const weatherAPI = config.keys.WEATHERSTACK_KEY;
+    const weatherUrl = `http://api.weatherstack.com/current?access_key=${weatherAPI}&query=${latitude},${longitude}`;
+    // printing a small forecast to the user 
+    request({ url: weatherUrl, json: true }, (error, response) => {
+        if (error) {
+            callback('Unable to connect to weather service', undefined)
+        } else if (response.body.error) {
+            callback(`The following error have been found: ${response.body.error.info}`)
+        } else {
+            data = response.body.current;
+            callback(undefined, 'It is currently ' + chalk.green.bold(data.temperature) + ' degrees out! It feels like ' + chalk.yellow.bold(data.feelslike) + ' degrees out. It is ' + chalk.green(data.weather_descriptions[0].toLowerCase()) + '.'
+            )
+        }
+    });
+
+}
+
+module.exports = forecast


### PR DESCRIPTION
//
// Goal: Create a reusable function for getting the forecast
//
// 1. Setup the "forecast" function in utils/forecast.js
// 2. Require the function in app.js and call it as shown below
// 3. The forecast function should have three potential calls to callback:
//    - Low level error, pass string for error
//    - Coordinate error, pass string for error
//    - Success, pass forecast string for data (same format as from before)

forecast(-75.7088, 44.1545, (error, data) => {
  console.log('Error', error)
  console.log('Data', data)
})