### PR TITLE
setting up 404 error pages

### DIFF
--- a/web-server/templates/views/generic-error.hbs
+++ b/web-server/templates/views/generic-error.hbs
@@ -1,0 +1,27 @@
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="/css/styles.css">
+
+    <title>Document</title>
+</head>
+
+
+
+<body>
+    {{>header}}
+    <div class="error-page-wrap">
+        <article class="error-page gradient">
+            <hgroup>
+                <h1>404</h1>
+                <h2>Oops! page not found</h2>
+            </hgroup>
+        </article>
+    </div>
+    {{>footer}}
+</body>
+
+</html>

--- a/web-server/templates/views/help-error.hbs
+++ b/web-server/templates/views/help-error.hbs
@@ -1,0 +1,26 @@
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="/css/styles.css">
+
+    <title>Document</title>
+</head>
+
+
+<body>
+    {{>header}}
+    <div class="error-page-wrap">
+        <article class="error-page gradient">
+            <hgroup>
+                <h1>404</h1>
+                <h2>No help article found.</h2>
+            </hgroup>
+        </article>
+    </div>
+    {{>footer}}
+</body>
+
+</html>


### PR DESCRIPTION
* `404 errors` when page could not be found
   * `*` wildcard character to be used to idenfity the pages that could not be found yet.
   * `help/*` to specify more specific paths
   * the above mentioned routes have to be listed last as express looks for the routes starting from top to bottom in the doc. 
![image](https://user-images.githubusercontent.com/79845207/138058501-c3a90e8e-2393-4db1-9268-08d5409b4958.png)
