### PR TITLE
promise chaining

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,12 @@ This repository is based on the Udemy course  [The Complete Node.js Developer Co
       * `app.get("/users", (req, res) => { User.find({}).then((response) => { res.send(response)}).then((error) => { res.send(error)})})` for all users.
       * `app.get("/users/:id", (req, res) => { User.findOne({_id : req.params.id}).then((response) => { res.send(response)}).then((error) => { res.send(error)})})` for one user.
       * if empty response is given, that is considered a success, so you have to handle it manually (with if else)
+   * Promise Chaining
+      * if you try to perform more promises, you could technically integrate the second callback in the `then` promise of the first one. However, it has an issue with a lot of nesting and complexity, also duplicate code.
+      * with Promise Chaining we can simplify the code, by executing the first callback as usual, call the second callback within the `then` call with `return` and then stop the first `then` promise and create a second one: `function(a, b).then((response) => {return function(response, c)}).then((response) => {}).catch((error) => {})` * this gives a benefit of no nesting.
+      * `promise-chaining.js`
+         * require mongoose
+         * require model
 
 ### Comments
 #### NPM modules

--- a/playground/9-promises.js
+++ b/playground/9-promises.js
@@ -1,14 +1,30 @@
-const doWorkPromises = new Promise((resolve, reject) => {
-    setTimeout(() => {
-        // resolve([2, 3, 4, 5])
-        reject('Things went wrong')
-    }, 2000)
-})
+const add = (a, b) => {
+    return new Promise((resolve, reject) => {
+        setTimeout(() => {
+            resolve(a + b)
+        }, 2000)
+    })
+}
 
-doWorkPromises.then((result) => {
-    console.log('Success!')
-    console.log(result)
-}).catch((error) => {
-    console.log(error)
-})
+// add(1, 2).then((response) => {
+//     console.log(response)
+//     add(response, 5).then((response) => {
+//         console.log(response)
+//     }).catch((error) => {
+//         console.log(error)
+//     })
+// }).catch((error) => {
+//     console.log(error)
+// })
 
+add(1, 1)
+    .then((response) => {
+        console.log(response)
+        return add(response, 4)
+    })
+    .then((response) => {
+        console.log(response)
+    })
+    .catch((error) => {
+        console.log(error)
+    })

--- a/task-manager/playground/promise-chaining.js
+++ b/task-manager/playground/promise-chaining.js
@@ -1,0 +1,16 @@
+require('../src/db/mongoose')
+const { response } = require('express')
+const User = require('../src/models/user')
+
+// ObjectId("6185121b2796838599d8514a")
+
+User.findByIdAndUpdate('6185121b2796838599d8514a', {
+    age: 1
+}).then((response) => {
+    console.log(response)
+    return User.countDocuments({ age: 1 })
+}).then((response) => {
+    console.log(response)
+}).catch((error) => {
+    console.log(error)
+})

--- a/task-manager/src/index.js
+++ b/task-manager/src/index.js
@@ -42,7 +42,6 @@ app.get('/users/:id', (req, res) => {
     })
 })
 
-
 app.post('/tasks', (req, res) => {
     const task = new Task(req.body)
     task.save().then((response) => {


### PR DESCRIPTION
      * if you try to perform more promises, you could technically integrate the second callback in the `then` promise of the first one. However, it has an issue with a lot of nesting and complexity, also duplicate code.
      * with Promise Chaining we can simplify the code, by executing the first callback as usual, call the second callback within the `then` call with `return` and then stop the first `then` promise and create a second one: `function(a, b).then((response) => {return function(response, c)}).then((response) => {}).catch((error) => {})` * this gives a benefit of no nesting.
      * `promise-chaining.js`
         * require mongoose
         * require model