### PR TITLE
create user/task relationship

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,8 +493,27 @@ This repository is based on the Udemy course  [The Complete Node.js Developer Co
       * customize url from `users/:id` to `users/me` 
       * refactor your code using `req.user` where needed and remove any id lookups.
       * no need to check if user anymore exists as the method by default requires auth and hence user.
-
-
+* The User/Task Relationship
+   * `models/task.js` 
+      * add a new field `owner` with `type: mongoose.Schema.Types.ObjectId` and `required: true`
+      * another field: `ref: 'User' - creates a relationship
+      * drop the database in `Robo 3T` because you created new required field.
+   * `routers/task.js` 
+      * require `middleware/auth`
+      * adjust a route to include `auth` as second param
+      * adjust the Task object
+         * `...req.body` - ES6 dynamic shorthand to take all the fields from the body,
+         * `owner: req.user._id` - take the id from the user from the req as this is passed on via `auth`
+   * `index.js`
+      * 
+   * `models/user.js`
+      * create a virtual model - relationship between two entities
+      * `userSchema.virtual('tasks', {})` - sets up many to one relationship between two models without storing it in the database
+      * object params:
+         * `ref: 'Task'` object we are referring to
+         * `localField: '_id'` related field in this model
+         * `foreignField: 'owner'` related field in the other model
+})
 
 ### Comments
 #### NPM modules

--- a/task-manager/src/index.js
+++ b/task-manager/src/index.js
@@ -17,6 +17,16 @@ app.listen(port, () => {
     console.log(`Server is up on port: ${port}.`)
 })
 
+
+const main = async () => {
+    // const task = await Task.findById('619121adc50ec7a479ca6749')
+    // await task.populate('owner')
+    // console.log(task.owner)
+    const user = await User.findById('6191204eccb2029f7dbe5b2e')
+    await user.populate('tasks')
+    console.log(user.tasks)
+}
+main()
 // const pet = {
 //     name: 'Hal'
 // }

--- a/task-manager/src/models/task.js
+++ b/task-manager/src/models/task.js
@@ -9,6 +9,10 @@ const Task = mongoose.model('Task', {
     completed: {
         type: Boolean,
         default: false
+    },
+    owner: {
+        type: mongoose.Schema.Types.ObjectId,
+        required: true
     }
 })
 

--- a/task-manager/src/models/user.js
+++ b/task-manager/src/models/user.js
@@ -65,6 +65,12 @@ userSchema.statics.findByCredentials = async (email, password) => {
     return user
 }
 
+userSchema.virtual('tasks', {
+    ref: 'Task',
+    localField: '_id',
+    foreignField: 'owner'
+})
+
 userSchema.methods.toJSON = function () {
     const user = this
     const userObject = user.toObject()

--- a/task-manager/src/routers/task.js
+++ b/task-manager/src/routers/task.js
@@ -1,9 +1,14 @@
 const express = require('express')
 const Task = require('../models/task')
 const router = new express.Router()
+const auth = require('../middleware/auth')
 
-router.post('/tasks', async (req, res) => {
-    const task = new Task(req.body)
+router.post('/tasks', auth, async (req, res) => {
+    // const task = new Task(req.body)
+    const task = new Task({
+        ...req.body,
+        owner: req.user._id
+    })
     try {
         const taskNew = await task.save()
         res.status("201").send(taskNew)


### PR DESCRIPTION
* The User/Task Relationship
   * `models/task.js` 
      * add a new field `owner` with `type: mongoose.Schema.Types.ObjectId` and `required: true`
      * another field: `ref: 'User' - creates a relationship
      * drop the database in `Robo 3T` because you created new required field.
   * `routers/task.js` 
      * require `middleware/auth`
      * adjust a route to include `auth` as second param
      * adjust the Task object
         * `...req.body` - ES6 dynamic shorthand to take all the fields from the body,
         * `owner: req.user._id` - take the id from the user from the req as this is passed on via `auth`
   * `index.js`
      * 
   * `models/user.js`
      * create a virtual model - relationship between two entities
      * `userSchema.virtual('tasks', {})` - sets up many to one relationship between two models without storing it in the database
      * object params:
         * `ref: 'Task'` object we are referring to
         * `localField: '_id'` related field in this model
         * `foreignField: 'owner'` related field in the other model