### PR TITLE
setting up completed as dynamic variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,7 +541,16 @@ This repository is based on the Udemy course  [The Complete Node.js Developer Co
    * focus on `GET /tasks` route, because this is the only one that sends back an array of data
    * if you have a lot of data, it will be slow and outdated / unused data
    * will achieve it by using the `query parameters`
-
+   * best to use `await req.user.populate({ path: 'tasks', match: { "completed": "false"} }).execPopulate()` function to populate the tasks with a certain criteria, but does not work for me, so I am sticking to `find`.
+   * query params can be added to the API call `{{url}}/tasks?completed=true` and Postman automatically sees it as a `key`
+   * to make it dependent on the query params, do the following:
+      1. use your `find` or `populate` method with object `match` => `find(match)`
+      2. create a new `const` for that object with the basic criteria with id lookup => `const match = { owner: req.user._id }`
+      3. do an if lookup to assign the `completed` value if any `if (req.query.completed) {match.completed = req.query.completed === "true"}`
+   * with this setup you can now easily make three requests:
+      1. all tasks
+      2. completed tasks
+      3. incompleted tasks
 
 
 

--- a/task-manager/src/routers/task.js
+++ b/task-manager/src/routers/task.js
@@ -24,6 +24,10 @@ router.post('/tasks', auth, async (req, res) => {
 
 // GET /tasks?completed=true
 router.get('/tasks', auth, async (req, res) => {
+    const match = { owner: req.user._id }
+    if (req.query.completed) {
+        match.completed = req.query.completed === "true"
+    }
     try {
         // await req.user.populate({
         //     path: 'tasks',
@@ -31,7 +35,7 @@ router.get('/tasks', auth, async (req, res) => {
         //         "completed": "false"
         //     }
         // }).execPopulate()
-        const tasks = await Task.find({ completed: false, owner: req.user._id })
+        const tasks = await Task.find(match)
         if (tasks.length === 0) {
             return res.status('404').send(req.user.tasks)
         }


### PR DESCRIPTION
* best to use `await req.user.populate({ path: 'tasks', match: { "completed": "false"} }).execPopulate()` function to populate the tasks with a certain criteria, but does not work for me, so I am sticking to `find`.
   * query params can be added to the API call `{{url}}/tasks?completed=true` and Postman automatically sees it as a `key`
   * to make it dependent on the query params, do the following:
      1. use your `find` or `populate` method with object `match` => `find(match)`
      2. create a new `const` for that object with the basic criteria with id lookup => `const match = { owner: req.user._id }`
      3. do an if lookup to assign the `completed` value if any `if (req.query.completed) {match.completed = req.query.completed === "true"}`
   * with this setup you can now easily make three requests:
      1. all tasks
      2. completed tasks
      3. incompleted tasks