### PR TITLE
moving static values to .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -732,6 +732,14 @@ This repository is based on the Udemy course  [The Complete Node.js Developer Co
       * if we leave the api key here, it becomes publicly available.
       * replace your `const config = require('../../../config')` and `const sengridApiKey = config.keys.SENDGRID_KEY` as the key for `sgMail.setApiKey()` and instead use `sgMail.setApiKey(process.env.SENDGRID_API_KEY)` (after you defined a `SENDGRID_API_KEY` in your `dev.env` file)
       * test it and see that the email sendout will still work.
+   * JWT token variable
+      * add JWT_SECRET to your env.dev file
+      * `models/user` replace the static value
+      * `middleware/auth` replace the static value
+   * Mongoose URL variable
+      * add MONGODB_URL to your env.dev file
+      * `db/mongoose` replace the static value with MONGODB_URL variable
+
 
 
 
@@ -897,7 +905,3 @@ This repository is based on the Udemy course  [The Complete Node.js Developer Co
    * go to your `main` branch and make sure that the changes are there.'
    * `heroku buildpacks:set heroku/nodejs` specify language
    * `git push heroku 
-
-
-
-test

--- a/task-manager/src/db/mongoose.js
+++ b/task-manager/src/db/mongoose.js
@@ -2,7 +2,7 @@ const mongoose = require('mongoose');
 const { stringify } = require('querystring');
 
 mongoose.connect(
-    'mongodb://127.0.0.1:27017/task-manager-api',
+    process.env.MONGODB_URL,
     { useNewUrlParser: true }
 )
 

--- a/task-manager/src/middleware/auth.js
+++ b/task-manager/src/middleware/auth.js
@@ -5,7 +5,7 @@ const User = require('../models/user')
 const auth = async (req, res, next) => {
     try {
         const token = req.header('Authorization').replace('Bearer ', '')
-        const decoded = jwt.verify(token, 'thisismynewcourse')
+        const decoded = jwt.verify(token, process.env.JWT_SECRET)
         const user = await User.findOne({ _id: decoded._id, 'tokens.token': token })
         if (!user) {
             throw new Error()

--- a/task-manager/src/models/user.js
+++ b/task-manager/src/models/user.js
@@ -90,7 +90,7 @@ userSchema.methods.toJSON = function () {
 // generate JWT for user
 userSchema.methods.generateAuthToken = async function () {
     const user = this
-    const token = jwt.sign({ _id: user._id.toString() }, 'thisismynewcourse')
+    const token = jwt.sign({ _id: user._id.toString() }, process.env.JWT_SECRET)
     user.tokens = user.tokens.concat({ token: token })
     await user.save()
     return token


### PR DESCRIPTION
* Environment Variables
   * currently our only `.env` variable is setup when we are defining `port` for heroku.
   * now we will set it up to also work locally for:
      * security
      * customization
   * `db/mongoose.js` 
      * `mongodb://127.0.0.1:27017/task-manager-api` connects to our local database, won't work when deployed to heroku. One value for DEV, one for PROD.
      * without env variables, we would not be able to customize it.
   * `index.js`
      * setup own environment variable for PORT
      * create a `config` folder and `dev.env` file in there
         * this file consists of key/value pairs, one on each line `key=value` with no spaces, commas, etc.
         * now you can remove the 3000 from `index.js`
      * use `env-cmd` npm module to use env variables
         * install `npm i env-cmd@10.1.0 --save-dev` because we only need it locally on our maschine and not on heroku
         * you will see it in the `package.json` file under `devDependencies`
      * adjust the script for `dev` in `package.json`
         * `env-cmd -f ./config/dev.env nodemon src/index.js` 
         * now when we run the dev command, `env-cmd` is going to grab all of the environment variables & then continue to run the node application with provided variables.
         * now when you will run `npm run dev` it will retreive the right env variable. If you change it, you have to restart your server.
   * `accounts.js`
      * if we leave the api key here, it becomes publicly available.
      * replace your `const config = require('../../../config')` and `const sengridApiKey = config.keys.SENDGRID_KEY` as the key for `sgMail.setApiKey()` and instead use `sgMail.setApiKey(process.env.SENDGRID_API_KEY)` (after you defined a `SENDGRID_API_KEY` in your `dev.env` file)
      * test it and see that the email sendout will still work.
   * JWT token variable
      * add JWT_SECRET to your env.dev file
      * `models/user` replace the static value
      * `middleware/auth` replace the static value
   * Mongoose URL variable
      * add MONGODB_URL to your env.dev file
      * `db/mongoose` replace the static value with MONGODB_URL variable

