### PR TITLE
adding tokens and authorization headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -906,7 +906,28 @@ This repository is based on the Udemy course  [The Complete Node.js Developer Co
       1. `test('Should log in existing user', async () => {})`
       2. `await request(app).post('/users/login').send({})`
       3. `.expect(200)`
-    
+* Testing with Authentication
+   * we will need an authentication token here.
+   * start by modifying the way you create your test user to make sure they have an authentication token
+      1. load in `jwt` for token generation: `const jwt = require('jsonwebtoken')`
+      2. load in `mongoose` for ObjectID generation:`const mongoose = require("mongoose")`
+      3. create ObjectID by `const userOneID = new mongoose.Types.ObjectId`
+      4. add it to the user `_id: userOneID`
+      5. create a token `tokens: [{token: jwt.sign({ _id: userOneID }, process.env.JWT_SECRET)}]` with id and secret
+   * now you can setup tests for use cases that require authentication
+      1. `test('Should get profile for existing user', async () => {})`
+      2. `await request(app).get('/users/me').send().expect(200)`
+      3. the first two lines above was the same as for any other test, but the problem is that so far we do not set up the authentication header nowhere
+      4. add the `set` call to add the authorization header `.set('Authorization', Bearer ${userOne.tokens[0].token})`
+   * set up test cases for
+      1. 'Should delete account for user'
+      2. 'Should not delete account for unauthenticated user'
+      3. 'Should get profile for existing user'
+      4. 'Should not get profile for unauthenticated user'
+
+
+
+
 
             
 ### Comments

--- a/task-manager/tests/user.test.js
+++ b/task-manager/tests/user.test.js
@@ -1,20 +1,25 @@
 const request = require('supertest')
-const app = require('../src/app')
-const User = require('../src/models/user')
+const jwt = require('jsonwebtoken')
 const mongoose = require("mongoose")
 
+const app = require('../src/app')
+const User = require('../src/models/user')
 
+const userOneID = new mongoose.Types.ObjectId()
 const userOne = {
+    _id: userOneID,
     name: "User One Ieva",
     email: "ieva.aleksandravica+userone@gmail.com",
-    password: "userOneIeva123"
+    password: "userOneIeva123",
+    tokens: [{
+        token: jwt.sign({ _id: userOneID }, process.env.JWT_SECRET)
+    }]
 }
 
 beforeEach(async () => {
     await User.deleteMany()
     await new User(userOne).save()
 })
-
 
 afterAll(() => {
     mongoose.connection.close();
@@ -48,4 +53,34 @@ test('Should not log in non-existent user', async () => {
             password: "appleapple"
         })
         .expect(404)
+})
+
+test('Should get profile for existing user', async () => {
+    await request(app)
+        .get('/users/me')
+        .set('Authorization', `Bearer ${userOne.tokens[0].token}`)
+        .send()
+        .expect(202)
+})
+
+test('Should not get profile for unauthenticated user', async () => {
+    await request(app)
+        .get('/users/me')
+        .send()
+        .expect(401)
+})
+
+test('Should delete account for user', async () => {
+    await request(app)
+        .delete('/users/me')
+        .set('Authorization', `Bearer ${userOne.tokens[0].token}`)
+        .send()
+        .expect(200)
+})
+
+test('Should not delete account for unauthenticated user', async () => {
+    await request(app)
+        .delete('/users/me')
+        .send()
+        .expect(401)
 })


### PR DESCRIPTION
* Testing with Authentication
   * we will need an authentication token here.
   * start by modifying the way you create your test user to make sure they have an authentication token
      1. load in `jwt` for token generation: `const jwt = require('jsonwebtoken')`
      2. load in `mongoose` for ObjectID generation:`const mongoose = require("mongoose")`
      3. create ObjectID by `const userOneID = new mongoose.Types.ObjectId`
      4. add it to the user `_id: userOneID`
      5. create a token `tokens: [{token: jwt.sign({ _id: userOneID }, process.env.JWT_SECRET)}]` with id and secret
   * now you can setup tests for use cases that require authentication
      1. `test('Should get profile for existing user', async () => {})`
      2. `await request(app).get('/users/me').send().expect(200)`
      3. the first two lines above was the same as for any other test, but the problem is that so far we do not set up the authentication header nowhere
      4. add the `set` call to add the authorization header `.set('Authorization', Bearer ${userOne.tokens[0].token})`
   * set up test cases for
      1. 'Should delete account for user'
      2. 'Should not delete account for unauthenticated user'
      3. 'Should get profile for existing user'
      4. 'Should not get profile for unauthenticated user'